### PR TITLE
Allow pnpm for node containers

### DIFF
--- a/.github/workflows/build_node.yml
+++ b/.github/workflows/build_node.yml
@@ -14,23 +14,8 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        node: ['10', '16', '18', '20', '22', '24']
-        debian: ['buster', 'bullseye', 'bookworm']
-        exclude:
-          - node: 10
-            debian: bullseye
-          - node: 10
-            debian: bookworm
-          - node: 16
-            debian: buster
-          - node: 18
-            debian: buster
-          - node: 20
-            debian: buster
-          - node: 22
-            debian: buster
-          - node: 24
-            debian: buster
+        node: ['16', '18', '20', '22', '24']
+        debian: ['bullseye', 'bookworm']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -52,7 +37,7 @@ jobs:
       - name: Build
         uses: docker/build-push-action@v3
         with:
-          context: debian/
+          context: debian/node
           platforms: linux/amd64
           push: true
           tags: |

--- a/debian/node/Dockerfile
+++ b/debian/node/Dockerfile
@@ -1,0 +1,29 @@
+ARG FROM_IMAGE
+FROM $FROM_IMAGE
+LABEL org.opencontainers.image.source = "https://github.com/EugenMayer/docker-image-azure"
+
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+# Install sudo, jq, make, m4, wget
+RUN apt-get update && apt-get upgrade -y \
+  && apt-get install -y \
+  # support for azure pipelines
+  sudo \
+  # support for generic makefile
+  make m4 \
+  # support for binary download support for tool belt extensions
+  curl wget \
+  # support for usual configuration / output parsing during builds
+  jq \
+  # support for running under specific users
+  gosu \
+  # general tools
+  git openssh-client rsync \
+  && rm -rf /tmp/* /var/tmp/* \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -fr /tmp/*.deb \
+  && rm -rf /usr/share/man/?? \
+  && rm -rf /usr/share/man/??_*


### PR DESCRIPTION
Introduce support for pnpm in the Node.js Docker containers by adding a new Dockerfile and updating the build workflow to accommodate the changes. This enhances package management capabilities within the container environment.

Also removing legacy containers based on node v10 and debian buster